### PR TITLE
Fix npm package name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ```bash
-$ npm install wpcom-oauth
+$ npm install node-wpcom-oauth
 ```
 
 ## API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "wpcom-oauth",
-  "description": "WordPress.com OAuth2 authorization module for Node.js",
+  "name": "node-wpcom-oauth",
+  "description": "WordPress.com OAuth2 server-side authorization module for Node.js",
   "version": "0.3.2",
   "author": "Automattic, Inc.",
   "repository": {


### PR DESCRIPTION
`wpcom-oauth` is a separate package: the client-side CORS counterpart to this module.
