### PR TITLE
Revert "Fix npm package name"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ```bash
-$ npm install node-wpcom-oauth
+$ npm install wpcom-oauth
 ```
 
 ## API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-wpcom-oauth",
-  "description": "WordPress.com OAuth2 server-side authorization module for Node.js",
+  "name": "wpcom-oauth",
+  "description": "WordPress.com OAuth2 authorization module for Node.js",
   "version": "0.3.2",
   "author": "Automattic, Inc.",
   "repository": {


### PR DESCRIPTION
Reverts Automattic/node-wpcom-oauth#7

per discussion with @TooTallNate and @retrofox we'll use `wpcom-oauth` here and `wpcom-oauth-cors` for the client-side module instead.