### PR TITLE
Add .json extension when referencing default.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var debug = require('debug')('wpcom-oauth');
  * Default options
  */
 
-var def = require('./default');
+var def = require('./default.json');
 
 /**
  * Options


### PR DESCRIPTION
While working on merging [wp-desktop](https://github.com/Automattic/wp-desktop) in to [wp-calypso](https://github.com/Automattic/wp-calypso), I hit an issue where webpack was attempting to bundle this package but failing when trying to resolve `./desktop`.
On inspection I realised that this is because I did not have `.json` included in my webpacks `resolve` configuration - doing so does fix the issue - but I thought that there may be more value in just being more explicit here in the packages source 😃.